### PR TITLE
Update Logs.php

### DIFF
--- a/Logs.php
+++ b/Logs.php
@@ -51,7 +51,7 @@ $options = Typecho_Widget::widget('Widget_Options');
                         </div>
                         <div class="search" style="margin: 10px;" role="search">
                             <div class="search-ip-group">
-                                <input type="text" class="search-ip text-s" value="<?php echo htmlspecialchars($request->ip); ?>" name="ip" placeholder="<?php _e("请输入 IP 搜索"); ?>" />
+                                <input type="text" class="search-ip text-s" value="<?php echo htmlspecialchars($request->ip ?? ''); ?>" name="ip" placeholder="<?php _e("请输入 IP 搜索"); ?>"/>
                                 <a class="clear-search-ip" href="#" title="<?php _e("取消 IP 筛选"); ?>">x</a>
                             </div>
                             <select class="search-bot" name="bot">


### PR DESCRIPTION
修复搜索框报错
<br /><b>Deprecated</b>:  htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in <b>/www/wwwroot/yanhy.top/usr/plugins/SpiderTracker/Logs.php</b> on line <b>54</b><br />
![image](https://github.com/DamonHu/Typecho-SpiderTracker/assets/62503474/321aa46a-9ebf-4e29-9aa7-4693f19b6973)
